### PR TITLE
Allow 0 for weekday

### DIFF
--- a/async_cron/job.py
+++ b/async_cron/job.py
@@ -106,7 +106,7 @@ class CronJob:
             if now >= self.next_run:
                 return True
         else:
-            if self.month_day and self.month_day != now.day:
+            if self.month_day is not None and self.month_day != now.day:
                 return False
             if self.week_day and self.week_day != now.weekday():
                 return False

--- a/async_cron/job.py
+++ b/async_cron/job.py
@@ -106,9 +106,9 @@ class CronJob:
             if now >= self.next_run:
                 return True
         else:
-            if self.month_day is not None and self.month_day != now.day:
+            if self.month_day and self.month_day != now.day:
                 return False
-            if self.week_day and self.week_day != now.weekday():
+            if self.week_day is not None and self.week_day != now.weekday():
                 return False
             now_datetime = now.datetime
             hour, minute = self.at_time


### PR DESCRIPTION
'0' is a valid weekday returned from now.weekday(), but the logic currently will treat this the same as if a weekday had not been set. So instead, check for is None directly.